### PR TITLE
[MFMA][FRONTEND] Add more options for forced mfma layout sizes 

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -152,8 +152,15 @@ compared to 1*64 when the hasLeadingOffset is false.
             auto mDim = mfmaEnc.getMDim();
             auto nDim = mfmaEnc.getNDim();
             auto nonKDim = dotOpEnc.getOpIdx() == 0 ? mDim : nDim;
-            if (4 == nonKDim)
-               maxPhase = 4;
+            // limit maxPhase and perPhase so full maxPhase*perPhase fits into one MFMA tile.
+            // One load operation loads elements of only one tile,
+            // it is meaningless to swizzle between tiles.
+            if (maxPhase * perPhase > nonKDim) {
+              maxPhase = std::max(1u, nonKDim / perPhase);
+              // just cleanup, for unswizzled case
+              if (maxPhase == 1)
+                perPhase = 1;
+            }
             assert(maxPhase > 0);
 
             return get(context, vecSize, perPhase, maxPhase, order, CTALayout);

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -1221,7 +1221,7 @@ private:
     if (mfmaLayout.getIsTransposed()) {
       multiDimBase[1] =
           add(mul(i32_val(4), udiv(laneId, i32_val(mDim))), offWarp1);
-      multiDimBase[0] = add(urem(laneId, i32_val(nDim)), offWarp0);
+      multiDimBase[0] = add(urem(laneId, i32_val(mDim)), offWarp0);
     } else {
       multiDimBase[0] =
           add(mul(i32_val(4), udiv(laneId, i32_val(nDim))), offWarp0);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
@@ -169,8 +169,20 @@ public:
     unsigned mDim = 0;
     unsigned nDim = 0;
     if (enforcedNonKDim != 0) {
-      mDim = enforcedNonKDim;
-      nDim = enforcedNonKDim;
+      if (enforcedNonKDim == 32 || enforcedNonKDim == 16 ||
+          enforcedNonKDim == 4) {
+        mDim = enforcedNonKDim;
+        nDim = enforcedNonKDim;
+      } else if (enforcedNonKDim == 464) {
+        mDim = 4;
+        nDim = 64;
+      } else if (enforcedNonKDim == 644) {
+        mDim = 64;
+        nDim = 4;
+      } else {
+        llvm::report_fatal_error("Invalid MFMA nonKDim option, supported "
+                                 "values are: 32, 16, 4, 464, 644");
+      }
     } else {
       int minSize = std::min(resShape[0], resShape[1]);
       if (minSize >= 32) {

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
@@ -168,7 +168,14 @@ public:
 
     unsigned mDim = 0;
     unsigned nDim = 0;
-    if (enforcedNonKDim != 0) {
+    auto matrixNonKDimAttr =
+        dot.getOperation()->getDiscardableAttr("tt.matrix_instr_nonkdim");
+    if (matrixNonKDimAttr) {
+      auto instrNonKDim =
+          matrixNonKDimAttr.cast<mlir::DenseIntElementsAttr>().getValues<int>();
+      mDim = instrNonKDim[0];
+      nDim = instrNonKDim[1];
+    } else if (enforcedNonKDim != 0) {
       if (enforcedNonKDim == 32 || enforcedNonKDim == 16 ||
           enforcedNonKDim == 4) {
         mDim = enforcedNonKDim;

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1665,6 +1665,18 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
                           for non_k_dim in [0, 4, 16, 32]
                           if not (allow_tf32 and (in_dtype in ['float16']))] +
 
+                         [(*shape, 1, False, False, epilogue, allow_tf32, in_dtype, out_dtype, non_k_dim, 1)
+                          for shape in [(64, 16, 16), (16, 64, 16)]
+                          for epilogue in ['none', 'trans', 'add-matrix', 'chain-dot', 'softmax']
+                          for allow_tf32 in [False]
+                          for in_dtype, out_dtype in [('float16', 'float16'),
+                                                      ('bfloat16', 'float32'),
+                                                      ('float8e5m2fnuz', 'float32'),
+                                                      ('float8e4m3fnuz', 'float32'),
+                                                      ('float16', 'float32'),
+                                                      ('float32', 'float32')]
+                          for non_k_dim in [0, 464, 644]] +
+
                          [(*shape_nw, col_a, col_b, 'none', allow_tf32, in_dtype, out_dtype, non_k_dim, kpack)
                           for shape_nw in [[128, 128, 32, 2],
                                            [128, 16, 32, 4],
@@ -1728,6 +1740,9 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
             pytest.skip("incompatible non_k_dim == 4 with K size")
         if non_k_dim == 4 and (M > 16 or N > 16):
             pytest.skip("skipping large matrices for non_k_dim == 4 to speedup testing")
+        if (non_k_dim == 464 and N < 64) or (non_k_dim == 644 and M < 64):
+            pytest.skip(f"skipping non_k_dim={non_k_dim} specific test with incompatible matrix sizes")
+
 
     if capability[0] < 7:
         pytest.skip("Only test tl.dot() on devices with sm >= 70")

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -1867,7 +1867,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
 
     z_tri = to_triton(z, device=device)
     if epilogue == 'trans':
-        z_tri = torch.as_strided(z_tri, (M, N), z_tri.stride()[::-1])
+        z_tri = torch.as_strided(z_tri, (M, N), [1, M])
 
     if out_dtype == 'int8':
         out_dtype = tl.int8

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1042,7 +1042,7 @@ def expand_dims(input, axis, _builder=None):
 
 
 @builtin
-def dot(input, other, acc=None, allow_tf32=True, max_num_imprecise_acc=None, out_dtype=float32, _builder=None):
+def dot(input, other, acc=None, allow_tf32=True, max_num_imprecise_acc=None, out_dtype=float32, matrix_instr_nonkdim=[], _builder=None):
     """
     Returns the matrix product of two blocks.
 
@@ -1056,7 +1056,7 @@ def dot(input, other, acc=None, allow_tf32=True, max_num_imprecise_acc=None, out
     allow_tf32 = _constexpr_to_value(allow_tf32)
     out_dtype = _constexpr_to_value(out_dtype)
     max_num_imprecise_acc = _constexpr_to_value(max_num_imprecise_acc)
-    return semantic.dot(input, other, acc, allow_tf32, max_num_imprecise_acc, out_dtype, _builder)
+    return semantic.dot(input, other, acc, allow_tf32, max_num_imprecise_acc, out_dtype, matrix_instr_nonkdim, _builder)
 
 
 # -----------------------

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1210,7 +1210,7 @@ def mfma_supported(M, N, K, allow_tf32, ret_scalar_ty, target) -> bool:
 
 
 def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, allow_tf32: bool, max_num_imprecise_acc: int,
-        out_dtype: tl.dtype, builder: ir.builder) -> tl.tensor:
+        out_dtype: tl.dtype, matrix_instr_nonkdim: list[int], builder: ir.builder) -> tl.tensor:
 
     def assert_dtypes_valid(lhs_dtype, rhs_dtype, target):
         # Checks for non-cuda archs
@@ -1341,6 +1341,8 @@ def dot(lhs: tl.tensor, rhs: tl.tensor, acc: tl.tensor, allow_tf32: bool, max_nu
         ret_ty = tl.block_type(ret_dot_scalar_ty, [M, N])
         ret = tl.tensor(builder.create_dot(lhs.handle, rhs.handle, _0, allow_tf32, max_num_imprecise_acc),
                         ret_ty)
+        if len(matrix_instr_nonkdim) > 0:
+            ret.handle.set_attr("tt.matrix_instr_nonkdim", ir.make_attr(matrix_instr_nonkdim, ret.handle.get_context()))
         return cast(ret, ret_scalar_ty, builder)
 
     _0 = builder.create_splat(_0, [M, N])


### PR DESCRIPTION
This pr:
- adds 64x4 and 4x64 layouts for kernel option `matrix_instr_nonkdim`: 464 corresponds 4(M)x64(N), 644 corresponds 64(M)x4(N)
- adds new per-dot option matrix_instr_nonkdim
- fixes swizzling patterns
- fixes mfma 4x64 layout index computations

per-operation option is used like this:

``` python
@triton.jit
def kernel(...):
    ...
    c = tl.dot(a, b, matrix_instr_nonkdim = [4, 64])
    ...
```

MFMA size heuristic now looks like this:

1. If dot specific option is set, pick it
2. If kernel specific option is set, pick it
3. If the result tile shape is larger than 32x32, pick mfma32
4. If the tile shape is smaller than 32x32 but larger than 16x16, pick mfma16
5. if the tile shape is smaller than 4x64 or 64x4, pick mfma4x4
6. Otherwise, pick mfma4x64 or mfma64x4, depending on what tile fits into matrices