### PR TITLE
[MFMA] Remove redundant checks

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -126,8 +126,6 @@ bool maybeSharedAllocationOp(Operation *op);
 bool maybeAliasOp(Operation *op);
 
 #ifdef USE_ROCM
-bool supportMFMA(triton::DotOp op);
-
 bool supportWMMA(triton::DotOp op);
 #endif
 

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -424,69 +424,6 @@ bool supportMMA(triton::DotOp op, int version) {
 }
 
 #ifdef USE_ROCM
-static bool supportMFMAGranularity(int m, int n, int k) {
-  // these limitations are dtype dependent, in future we may relax them
-  const static std::tuple<int, int, int> mfmaTypes[] = {
-      {32, 32, 8}, {16, 16, 16}, {4, 4, 64}, {64, 4, 4}, {4, 64, 4}};
-  for (const auto &mfmaType : mfmaTypes) {
-    auto [granularityM, granularityN, granularityK] = mfmaType;
-    if (m % granularityM != 0 || n % granularityN != 0)
-      continue;
-    if (k % granularityK != 0)
-      continue;
-    return true;
-  }
-  return false;
-}
-
-bool supportMFMATypes(Type a, Type b) {
-  if (a.getIntOrFloatBitWidth() != b.getIntOrFloatBitWidth())
-    return false;
-
-  auto F8E4M3FNUZ = TypeID::get<mlir::Float8E4M3FNUZType>();
-  auto F8E5M2FNUZ = TypeID::get<mlir::Float8E5M2FNUZType>();
-  auto F16 = TypeID::get<mlir::Float16Type>();
-  auto BF16 = TypeID::get<mlir::BFloat16Type>();
-  auto F32 = TypeID::get<mlir::Float32Type>();
-  auto Int = TypeID::get<mlir::IntegerType>();
-  const static DenseSet<std::pair<mlir::TypeID, mlir::TypeID>> supportedTypes = {
-      {F32, F32},
-      {F16, F16},
-      {BF16, BF16},
-      {F8E4M3FNUZ, F8E4M3FNUZ},
-      {F8E4M3FNUZ, F8E5M2FNUZ},
-      {F8E5M2FNUZ, F8E4M3FNUZ},
-      {F8E5M2FNUZ, F8E5M2FNUZ},
-      {Int, Int}};
-
-  if (!supportedTypes.contains({a.getTypeID(), b.getTypeID()}))
-    return false;
-
-  if (a.isIntOrIndex() && a.getIntOrFloatBitWidth() != 8)
-    return false;
-  return true;
-}
-
-bool supportMFMA(triton::DotOp op) {
-  auto aTy = op.getA().getType().cast<RankedTensorType>();
-  auto bTy = op.getB().getType().cast<RankedTensorType>();
-
-  auto aElemTy = aTy.getElementType();
-  auto bElemTy = bTy.getElementType();
-
-  if (!supportMFMATypes(aElemTy, bElemTy))
-    return false;
-
-  auto aShape = aTy.getShape();
-  auto bShape = bTy.getShape();
-
-  assert(aShape[1] == bShape[0]);
-  if (!supportMFMAGranularity(aShape[0], bShape[1], aShape[1]))
-    return false;
-
-  return true;
-}
-
 static bool supportWMMAGranularity(int m, int n, int k) {
   return m % 16 == 0 && n % 16 == 0 && k % 16 == 0;
 }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM.cpp
@@ -82,7 +82,7 @@ struct DotOpConversion : public ConvertTritonGPUOpToLLVMPattern<triton::DotOp> {
                                       .cast<RankedTensorType>()
                                       .getEncoding()
                                       .dyn_cast<MfmaEncodingAttr>();
-    if (!isOuter && mfmaLayout && supportMFMA(op)) {
+    if (!isOuter && mfmaLayout) {
       return convertMFMA(op, adaptor, getTypeConverter(), rewriter);
     }
 #endif

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateAMDMatmul.cpp
@@ -210,9 +210,6 @@ public:
         !oldRetType.getEncoding().isa<ttg::BlockedEncodingAttr>())
       return failure();
 
-    if (!supportMFMA(dotOp))
-      return failure();
-
     auto CTALayout = ttg::getCTALayout(oldRetType.getEncoding());
     assert(CTALayout.getCTAsPerCGA().size() == 2);
     assert(CTALayout.getCTAsPerCGA()[0] == 1);

--- a/python/triton/third_party/hip/include/triton/AnalysisROCM/Utility.h
+++ b/python/triton/third_party/hip/include/triton/AnalysisROCM/Utility.h
@@ -114,10 +114,6 @@ bool maybeSharedAllocationOp(Operation *op);
 
 bool maybeAliasOp(Operation *op);
 
-#if 1
-bool supportMFMA(triton::DotOp op, int64_t nonKDim);
-#endif
-
 bool supportMMA(triton::DotOp op, int version);
 
 bool supportMMA(Value value, int version);

--- a/python/triton/third_party/hip/lib/AnalysisROCM/Utility.cpp
+++ b/python/triton/third_party/hip/lib/AnalysisROCM/Utility.cpp
@@ -377,40 +377,6 @@ bool supportMMA(triton::DotOp op, int version) {
   return supportMMA(op.getA(), version) && supportMMA(op.getB(), version);
 }
 
-#if 1
-static bool supportMFMAGranularity(int m, int n, int k, int64_t nonKDim) {
-  // these limitations are dtype dependent, in future we may relax them
-  const int granularityMN = nonKDim;
-  const int granularityK = nonKDim == 32 ? 8 : 16;
-  if (m % granularityMN != 0 || n % granularityMN != 0)
-    return false;
-  if (k % granularityK != 0)
-    return false;
-  return true;
-}
-
-bool supportMFMA(triton::DotOp op, int64_t nonKDim) {
-  auto aTy = op.getA().getType().cast<RankedTensorType>();
-  auto bTy = op.getB().getType().cast<RankedTensorType>();
-
-  auto aElemTy = aTy.getElementType();
-  auto bElemTy = bTy.getElementType();
-
-  if (aElemTy != bElemTy)
-    return false;
-
-  auto aShape = aTy.getShape();
-  auto bShape = bTy.getShape();
-
-  assert(aShape[1] == bShape[0]);
-  if (!supportMFMAGranularity(aShape[0], bShape[1], aShape[1], nonKDim))
-    return false;
-
-  return aElemTy.isF16() || aElemTy.isBF16() || aElemTy.isF32() ||
-         aElemTy.isInteger(8);
-}
-#endif
-
 bool supportMMA(Value value, int version) {
   // Tell whether a DotOp support MMA by the operand type(either $a or $b).
   // We cannot get both the operand types(in TypeConverter), here we assume the

--- a/python/triton/third_party/hip/lib/Conversion/TritonGPUROCMToLLVM/DotOpToLLVM.cpp
+++ b/python/triton/third_party/hip/lib/Conversion/TritonGPUROCMToLLVM/DotOpToLLVM.cpp
@@ -82,7 +82,7 @@ struct DotOpConversion : public ConvertTritonGPUOpToLLVMPattern<triton::DotOp> {
                                       .cast<RankedTensorType>()
                                       .getEncoding()
                                       .dyn_cast<MfmaEncodingAttr>();
-    if (!isOuter && mfmaLayout && supportMFMA(op, mfmaLayout.getNonKDim())) {
+    if (!isOuter && mfmaLayout)) {
       return convertMFMA(op, adaptor, getTypeConverter(), rewriter);
     }
 #endif

--- a/python/triton/third_party/hip/lib/Dialect/TritonGPUROCM/Transforms/AccelerateMatmul.cpp
+++ b/python/triton/third_party/hip/lib/Dialect/TritonGPUROCM/Transforms/AccelerateMatmul.cpp
@@ -220,9 +220,6 @@ public:
       assert(externalNonKDim == 32 || externalNonKDim == 16);
     }
 
-    if (!supportMFMA(dotOp, externalNonKDim))
-      return failure();
-
     auto CTALayout = ttg::getCTALayout(oldRetType.getEncoding());
 
     // get MFMA encoding for the given number of warps


### PR DESCRIPTION
This PR removes supportMFMA checks.
We do not need them since we new instruction selection is implemented.