### PR TITLE
HIP: Add RUNPATH to compiled so files.

### DIFF
--- a/python/triton/common/build.py
+++ b/python/triton/common/build.py
@@ -94,7 +94,7 @@ def _build(name, src, srcdir):
     if is_hip():
         ret = subprocess.check_call([
             cc, src, f"-I{hip_include_dir}", f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC",
-            f"-L{hip_lib_dir}", "-lamdhip64", "-o", so
+            f"-L{hip_lib_dir}", "-lamdhip64", f"-Wl,-rpath,{hip_lib_dir}", "-o", so
         ])
     else:
         cc_cmd = [


### PR DESCRIPTION
Fix a problem reported by [Pytorch CentOS docker creation failed due to Triton compilation, ImportError: libamdhip64.so.6](https://ontrack-internal.amd.com/browse/SWDEV-443861)

Analysis of this problem:
1. Some Triton libraries do not have `/opt/rocm/lib` in their `RUNPATH`. This leaves `ld` with only two options to find the `libamdhip64.so.6` file: `LD_LIBRARY_PATH` and `/etc/ld.so.conf`.
2. `LD_LIBRARY_PATH` may not contain `/opt/rocm/lib`
3. `/etc/ld.so.conf.d/*` files are being deprecated by ROCM and not reliable. `RUNPATH` is the new preferred way by ROCM to locate ROCM libraries, to support parallel installations.
