### PR TITLE
Add a script to run tests in `pytest test_core.py` separately

### DIFF
--- a/scripts/amd/check_test_core.sh
+++ b/scripts/amd/check_test_core.sh
@@ -11,6 +11,7 @@ TEST_CORE=./test/unit/language/test_core.py
 pytest --co -q ${TEST_CORE} | sed "s/\[.*\]//g" | awk '!a[$0]++' | sed -n "/test_core.py/p" > test_names.txt
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BRANCH=${BRANCH/\//-}
 COMMIT=$(git rev-parse --short HEAD)
 
 SUMMARY=${TEST_OUTPUT}/summary_${BRANCH}@${COMMIT}_$(date '+%m-%d-%Y-%H-%M-%S').txt
@@ -20,15 +21,21 @@ echo "Running test_core.py on ${BRANCH}@${COMMIT}" | tee -a ${SUMMARY}
 while read -r line; do
     test_name=${line##*::}
     if [[ ${line:0:1} != "#" ]];then
-        printf '%-45s' "${test_name}: " | tee -a $SUMMARY
+        printf '%-45s' "${test_name}: "
         Msg=$(pytest -v $line > ${TEST_OUTPUT}/${test_name}.output 2>&1)
         if [ $? -ne 0 ] && grep -Fq "Aborted" ${TEST_OUTPUT}/${test_name}.output; then
+            printf '%-45s' "${test_name}: " >> $SUMMARY
             printf "Aborted\n" | tee -a $SUMMARY
         else
             last_line=$(sed -n '/====/p' ${TEST_OUTPUT}/${test_name}.output | tail -n 1)
             report=${last_line#=* }
             report=${report%%in *}
-            printf "$report \n" | tee -a $SUMMARY
+            if [[ $report = *'failed'* ]] || [[ $report = *'skipped'* ]]; then
+                printf '%-45s' "${test_name}: " >> $SUMMARY
+                printf "$report \n" | tee -a $SUMMARY
+            else
+                printf "$report \n"
+            fi
         fi
     fi
 done < test_names.txt

--- a/scripts/amd/check_test_core.sh
+++ b/scripts/amd/check_test_core.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+TEST_OUTPUT=test_output
+cd $(git rev-parse --show-toplevel)/python
+
+if [ ! -d $TEST_OUTPUT ];then
+    mkdir $TEST_OUTPUT
+fi
+
+TEST_CORE=./test/unit/language/test_core.py
+pytest --co -q ${TEST_CORE} | sed "s/\[.*\]//g" | awk '!a[$0]++' | sed -n "/test_core.py/p" > test_names.txt
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT=$(git rev-parse --short HEAD)
+
+SUMMARY=${TEST_OUTPUT}/summary_${BRANCH}@${COMMIT}_$(date '+%m-%d-%Y-%H-%M-%S').txt
+
+echo "Running test_core.py on ${BRANCH}@${COMMIT}" | tee -a ${SUMMARY}
+
+while read -r line; do
+    test_name=${line##*::}
+    if [[ ${line:0:1} != "#" ]];then
+        printf '%-45s' "${test_name}: " | tee -a $SUMMARY
+        Msg=$(pytest -v $line > ${TEST_OUTPUT}/${test_name}.output 2>&1)
+        if [ $? -ne 0 ] && grep -Fq "Aborted" ${TEST_OUTPUT}/${test_name}.output; then
+            printf "Aborted\n" | tee -a $SUMMARY
+        else
+            last_line=$(sed -n '/====/p' ${TEST_OUTPUT}/${test_name}.output | tail -n 1)
+            report=${last_line#=* }
+            report=${report%%in *}
+            printf "$report \n" | tee -a $SUMMARY
+        fi
+    fi
+done < test_names.txt
+
+
+


### PR DESCRIPTION
## Description
This script runs each function in `test_core.py` separately and
- It can catch the core dump error and continue to run the next test function
- It writes pytest output for each function in a separate file 
- It writes the summary, which is more simplified than pytest summary, into another file

## Usage
1. **copy this script in upstream triton dir. Any location works since it can find its way to the `python` dir**.
2. Run it: `./check_test_core.sh`

The summary and pytest output for each test function are written to `/python/test_output/`.

## Sample output

```bash
Running test_core.py on run_test_core@35edd6a65
test_empty_kernel:                           12 passed
test_bin_op:                                 720 passed, 38 warnings
test_addptr:                                 24 passed
test_floordiv:                               32 passed
test_unsigned_name_mangling:                 1 passed
test_bitwise_op:                             1587 passed
... 
```