### PR TITLE
Unify hasConvertToMMATransisitiveUse

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -530,6 +530,12 @@ CTALayoutAttr getCTALayout(Attribute layout) {
                               getCTAOrder(sliceLayout));
   else if (auto mmaLayout = layout.dyn_cast<MmaEncodingAttr>())
     return mmaLayout.getCTALayout();
+#ifdef USE_ROCM
+  else if (auto mfmaLayout = layout.dyn_cast<MfmaEncodingAttr>())
+    return CTALayoutAttr::get(layout.getContext(), getCTAsPerCGA(mfmaLayout),
+                              getCTASplitNum(mfmaLayout),
+                              getCTAOrder(mfmaLayout));
+#endif
   else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>())
     return CTALayoutAttr::get(layout.getContext(), getCTAsPerCGA(dotLayout),
                               getCTASplitNum(dotLayout),


### PR DESCRIPTION
Unifying some code in RemoveLayoutConversions.cpp between NV and ROCm. The current ROCm path misses some update from the main repo. 