### PR TITLE
Causal masking with dissimilar Q/KV sequence lengths

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -27,12 +27,12 @@
 #include <set>
 #include <string>
 
-namespace triton {
+namespace mlir::triton {
 
 const std::set<std::string> ENV_VARS = {
     "DISABLE_MMA_V3",    "TRITON_DISABLE_LINE_INFO", "DISABLE_FAST_REDUCTION",
     "ENABLE_TMA",        "MLIR_ENABLE_DUMP",         "LLVM_IR_ENABLE_DUMP",
-    "AMDGCN_ENABLE_DUMP"};
+    "AMDGCN_ENABLE_DUMP", "TRUNCATE_F32_TO_BF16"};
 
 namespace tools {
 
@@ -46,7 +46,7 @@ inline std::string getenv(const char *name) {
 
 inline bool getBoolEnv(const std::string &env) {
   std::string msg = "Environment variable " + env + " is not recognized";
-  assert(::triton::ENV_VARS.find(env.c_str()) != ::triton::ENV_VARS.end() &&
+  assert(mlir::triton::ENV_VARS.find(env.c_str()) != mlir::triton::ENV_VARS.end() &&
          msg.c_str());
   const char *s = std::getenv(env.c_str());
   std::string str(s ? s : "");

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -397,7 +397,7 @@ bool supportMMA(triton::DotOp op, int version) {
   auto aElemTy = op.getA().getType().cast<RankedTensorType>().getElementType();
   auto bElemTy = op.getB().getType().cast<RankedTensorType>().getElementType();
   if (version == 3) {
-    if (::triton::tools::getBoolEnv("DISABLE_MMA_V3"))
+    if (mlir::triton::tools::getBoolEnv("DISABLE_MMA_V3"))
       return false;
     auto retType = op.getResult().getType().cast<RankedTensorType>();
     auto retShapePerCTA = triton::gpu::getShapePerCTA(retType);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -40,7 +40,7 @@ public:
     // Only insert fences for compute capability 9.0
     if (computeCapability < 90)
       return;
-    if (::triton::tools::getBoolEnv("DISABLE_MMA_V3"))
+    if (mlir::triton::tools::getBoolEnv("DISABLE_MMA_V3"))
       return;
     ModuleOp mod = getOperation();
     mod.walk([&](Operation *op) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MaterializeLoadStore.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MaterializeLoadStore.cpp
@@ -93,7 +93,7 @@ void MaterializeLoadStorePass::materializeLoadTilePtr(
     mlir::triton::LoadOp load) {
   if (computeCapability < 90)
     return;
-  if (!::triton::tools::getBoolEnv("ENABLE_TMA"))
+  if (!mlir::triton::tools::getBoolEnv("ENABLE_TMA"))
     return;
   auto loc = load.getLoc();
   OpBuilder b(load);
@@ -146,7 +146,7 @@ void MaterializeLoadStorePass::materializeLoadTilePtr(
 
 void MaterializeLoadStorePass::materializeStoreTilePtr(
     mlir::triton::StoreOp store) {
-  if (computeCapability < 90 || !::triton::tools::getBoolEnv("ENABLE_TMA"))
+  if (computeCapability < 90 || !mlir::triton::tools::getBoolEnv("ENABLE_TMA"))
     return;
   auto loc = store.getLoc();
   OpBuilder builder(store);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
@@ -72,7 +72,7 @@ bool isDivisible(Value v, unsigned divisor) {
 }
 
 bool shouldRemove(tt::MakeTensorPtrOp &op, int computeCapability) {
-  if (computeCapability < 90 || !::triton::tools::getBoolEnv("ENABLE_TMA"))
+  if (computeCapability < 90 || !mlir::triton::tools::getBoolEnv("ENABLE_TMA"))
     return true;
   auto resType = op.getResult()
                      .getType()
@@ -94,7 +94,7 @@ bool shouldRemove(tt::MakeTensorPtrOp &op, int computeCapability) {
   if (stride.size() == 2)
     strideDivisible =
         isDivisible(stride[ord[1]], 128 / elemType.getIntOrFloatBitWidth());
-  bool enableTMA = ::triton::tools::getBoolEnv("ENABLE_TMA");
+  bool enableTMA = mlir::triton::tools::getBoolEnv("ENABLE_TMA");
   return !(boxDimSwizzle && strideDivisible && enableTMA);
 }
 

--- a/lib/Target/HSACO/HSACOTranslation.cpp
+++ b/lib/Target/HSACO/HSACOTranslation.cpp
@@ -145,7 +145,7 @@ std::string generate_amdgcn_assembly(llvm::Module *module,
   pass.run(*module);
 
   std::string amdgcn(buffer.begin(), buffer.end());
-  if (::triton::tools::getBoolEnv("AMDGCN_ENABLE_DUMP")) {
+  if (mlir::triton::tools::getBoolEnv("AMDGCN_ENABLE_DUMP")) {
     llvm::dbgs() << "// -----// AMDGCN Dump //----- //\n" << amdgcn << '\n';
   }
 
@@ -156,7 +156,7 @@ std::string generate_hsaco(llvm::Module *module, const std::string &triple,
                            const std::string &proc,
                            const std::string &features) {
   auto machine = initialize_module(module, triple, proc, features);
-  std::string dump_path = ::triton::tools::getenv("AMDGCN_DUMP_PATH");
+  std::string dump_path = mlir::triton::tools::getenv("AMDGCN_DUMP_PATH");
   
   // create unique dir for kernel's binary and hsaco
   std::error_code ec;
@@ -235,7 +235,7 @@ std::string generate_hsaco(llvm::Module *module, const std::string &triple,
                                               "hip" / "llvm" / "bin" / "ld.lld";
   std::string lld_path = compiletime_path.string();
   if (!std::filesystem::exists(lld_path)) {
-    std::string rocm_path = ::triton::tools::getenv("ROCM_PATH");
+    std::string rocm_path = mlir::triton::tools::getenv("ROCM_PATH");
     lld_path = (rocm_path.empty()) ? ROCM_DEFAULT_DIR : rocm_path;
     lld_path += "/llvm/bin/ld.lld";
   }
@@ -312,7 +312,7 @@ void translateTritonToTritonGPU(mlir::ModuleOp &module,
       /*shouldPrintBeforePass=*/nullptr,
       /*shouldPrintAfterPass=*/
       [](mlir::Pass *pass, mlir::Operation *) {
-        return ::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
+        return mlir::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
       },
       /*printModuleScope=*/false,
       /*printAfterOnlyOnChange=*/true,
@@ -446,7 +446,7 @@ static std::map<std::string, std::string> getExternLibs(mlir::ModuleOp module) {
   if (!funcs.empty()) {
     static const std::string libdevice = "libdevice";
     // first search for environmental path
-    std::string env_path = ::triton::tools::getenv("TRITON_LIBDEVICE_PATH");
+    std::string env_path = mlir::triton::tools::getenv("TRITON_LIBDEVICE_PATH");
     if (!env_path.empty()) {
       externLibs.try_emplace(libdevice, env_path);
       return externLibs;
@@ -606,7 +606,7 @@ translateLLVMDialectToLLVMIR(llvm::LLVMContext *llvmContext,
     llvm::errs() << "Could not open file: " << EC.message() << "\n";
   }
 
-  if (::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
+  if (mlir::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
     std::string mod_string;
     std::unique_ptr<llvm::raw_string_ostream> ir_ss(
         new llvm::raw_string_ostream(mod_string));
@@ -643,7 +643,7 @@ void translateTritonGPUToLLVMDialect(mlir::ModuleOp &module,
       /*shouldPrintBeforePass=*/nullptr,
       /*shouldPrintAfterPass=*/
       [](mlir::Pass *pass, mlir::Operation *) {
-        return ::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
+        return mlir::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
       },
       /*printModuleScope=*/false,
       /*printAfterOnlyOnChange=*/true,

--- a/lib/Target/LLVMIR/LLVMIRTranslation.cpp
+++ b/lib/Target/LLVMIR/LLVMIRTranslation.cpp
@@ -296,7 +296,7 @@ static std::map<std::string, std::string> getExternLibs(mlir::ModuleOp module) {
   if (!funcs.empty()) {
     static const std::string libdevice = "libdevice";
     // first search for environmental path
-    std::string env_path = ::triton::tools::getenv("TRITON_LIBDEVICE_PATH");
+    std::string env_path = mlir::triton::tools::getenv("TRITON_LIBDEVICE_PATH");
     if (!env_path.empty()) {
       externLibs.try_emplace(libdevice, env_path);
       return externLibs;
@@ -458,7 +458,7 @@ translateTritonGPUToLLVMIR(llvm::LLVMContext *llvmContext,
       /*shouldPrintBeforePass=*/nullptr,
       /*shouldPrintAfterPass=*/
       [](mlir::Pass *pass, mlir::Operation *) {
-        return ::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
+        return mlir::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
       },
       /*printModuleScope=*/false,
       /*printAfterOnlyOnChange=*/true,
@@ -480,7 +480,7 @@ translateTritonGPUToLLVMIR(llvm::LLVMContext *llvmContext,
   pm.addPass(mlir::createConvertSCFToCFPass());
   pm.addPass(createConvertControlFlowToLLVMPass());
 #endif
-  if (!::triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO"))
+  if (!mlir::triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO"))
     pm.addPass(mlir::createLLVMDIScopePass());
 
   if (failed(pm.run(module))) {
@@ -494,7 +494,7 @@ translateTritonGPUToLLVMIR(llvm::LLVMContext *llvmContext,
     return nullptr;
   }
 
-  if (::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
+  if (mlir::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
     std::string mod_string;
     std::unique_ptr<llvm::raw_string_ostream> ir_ss(
         new llvm::raw_string_ostream(mod_string));

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -8,12 +8,10 @@ Credits: OpenAI kernel team, AMD ML Frameworks Triton team
 
 Features supported:
 
-1) Fwd + bwd kernel with causal masking
-2) Vector and matrix bias (currently fwd kernel only, no causal masking)
-3) Any sequence lengths without padding (currently fwd kernel only, no causal masking)
-4) fp8 (e5m2fnuz, QK GEMM in fwd kernel only)
-5) Support for different sequence lengths for q and k
-6) Nested tensor API currently does not support causal masking, dropout or bias.
+1) Fwd with causal masking
+2) Any sequence lengths without padding (currently fwd kernel only)
+3) Support for different sequence lengths for q and k
+4) Nested tensor API currently does not support dropout or bias.
 
 Not currently supported:
 

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -38,7 +38,6 @@ class MetaData():
     max_seqlens_q = 0
     max_seqlens_k = 0
     bias = None
-    bias_type = 0
     causal = False
     num_contexts = 0
     varlen = False
@@ -62,17 +61,9 @@ class MetaData():
     def need_bias(self, bias, batch, nheads, seqlen_q, seqlen_k):
         assert bias.is_cuda
         assert bias.dim() == 4
-        if bias.shape[2:] == (1, seqlen_k):
-            bias_type = 1
-        elif bias.shape[2:] == (seqlen_q, seqlen_k):
-            bias_type = 2
-        else:
-            raise RuntimeError(
-                "Last 2 dimensions of bias must be (1, seqlen)" " or (seqlen, seqlen)"
-            )
-
-        self.bias = bias.expand(batch, nheads, seqlen_q, seqlen_k)
-        self.bias_type = bias_type
+        assert bias.shape[0] == 1
+        assert bias.shape[2:] == (seqlen_q, seqlen_k)
+        self.bias = bias
 
     def need_causal(self):
         self.causal = True
@@ -95,8 +86,6 @@ class MetaData():
             # TODO:Remove once dropout is supported with varlen
             assert self.dropout_p == 0.0
             assert not self.return_encoded_softmax
-            # TODO: Remove once causal masking is supported with varlen
-            assert not self.causal
         else:
             assert q.dim() == 4
             batch, nheads_q, seqlen_q, head_size = q.shape
@@ -111,6 +100,10 @@ class MetaData():
         assert head_size <= 128
         assert o.shape == q.shape
         assert (nheads_q % nheads_k) == 0
+
+@triton.jit
+def cdiv_fn(x,y):
+    return (x + y - 1) // y
 
 @triton.jit
 def max_fn(x, y):
@@ -134,135 +127,88 @@ def dropout_mask(philox_seed, philox_offset, dropout_p, m, n, stride):
     rng_keep = rng_output > dropout_p
     return rng_keep
 
-# Only needed for testing
-def prepare_bias(bias, batch, nheads, seqlen_q, seqlen_k):
-    assert bias.is_cuda
-    assert bias.dim() == 4
-    if bias.shape[2:] == (1, seqlen_k):
-        bias_type = 1
-    elif bias.shape[2:] == (seqlen_q, seqlen_k):
-        bias_type = 2
+@triton.jit
+def load_fn(block_ptr, first, second, pad):
+    if first and second:
+        tensor = tl.load(block_ptr, boundary_check=(0,1), padding_option=pad)
+    elif first:
+        tensor = tl.load(block_ptr, boundary_check=(0,), padding_option=pad)
+    elif second:
+        tensor = tl.load(block_ptr, boundary_check=(1,), padding_option=pad)
     else:
-        raise RuntimeError(
-            "Last 2 dimensions of bias must be (1, seqlen)" " or (seqlen, seqlen)"
-        )
-    return bias.expand(batch, nheads, seqlen_q, seqlen_k), bias_type
+        tensor = tl.load(block_ptr)
+    return tensor
 
 @triton.jit
 def _attn_fwd_inner(
     acc, l_i, m_i, q,
     K_block_ptr, V_block_ptr,
     start_m,
-    seqlen_k,
+    actual_seqlen_k,
     dropout_p,
     philox_seed,
     batch_philox_offset,
     encoded_softmax_block_ptr,
+    block_min, block_max,
+    offs_n_causal,
+    masked_blocks,
+    n_extra_tokens,
+    bias_ptr,
+    IS_CAUSAL: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_N: tl.constexpr,
-    STAGE: tl.constexpr,
     OFFS_M: tl.constexpr,
     OFFS_N: tl.constexpr,
     PRE_LOAD_V: tl.constexpr,
-    PADDED_BLOCK: tl.constexpr,
-    TOTAL_TOKENS: tl.constexpr,
-    PADDED_HEAD: tl.constexpr,
-    bias_ptr,
+    MASK_STEPS: tl.constexpr,
     ENABLE_DROPOUT: tl.constexpr,
-    RETURN_ENCODED_SOFTMAX: tl.constexpr
+    RETURN_ENCODED_SOFTMAX: tl.constexpr,
+    PADDED_HEAD: tl.constexpr
 ):
-    # range of values handled by this stage
-    if STAGE == 1: # "Solid" blocks of Causal masks
-        lo, hi = 0, min(seqlen_k, start_m * BLOCK_M)
-    elif STAGE == 2: # "Semi-solid", or "Transition" block of Causal mask
-        # Must use BLOCK_M, because the starting position of semi-solid block
-        # is determined by start_m * BLOCK_M
-        lo, hi = start_m * BLOCK_M, min(seqlen_k, start_m * BLOCK_M + BLOCK_M)
-        lo = tl.multiple_of(lo, BLOCK_M)
-        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
-        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
-        if RETURN_ENCODED_SOFTMAX:
-            encoded_softmax_block_ptr = tl.advance(encoded_softmax_block_ptr, (0, lo))
-    # So here, we are computing the elements for that last irregular block.
-    # In the loop,  we will mask the elements of BLOCK_N that do not exist.
-    elif PADDED_BLOCK:
-        lo, hi = seqlen_k, seqlen_k + BLOCK_N
-        lo = tl.multiple_of(lo, BLOCK_N)
-        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
-        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
-        if bias_ptr is not None:
-            if bias_ptr.type.element_ty.is_block():
-                bias_ptr = tl.advance(bias_ptr, (0, lo))
-            else:
-                bias_ptr += lo
-    # causal = False
-    else:
-        lo, hi = 0, seqlen_k
-    # loop over k, v and update accumulator
-    for start_n in range(lo, hi, BLOCK_N):
-        if STAGE == 1 or STAGE == 3:
-            start_n = tl.multiple_of(start_n, BLOCK_N)
+    # loop over k, v, and update accumulator
+    for start_n in range (block_min, block_max, BLOCK_N):
         # For padded blocks, we will overrun the tensor size if
         # we load all BLOCK_N. For others, the blocks are all within range.
-        if PADDED_BLOCK:
-            if PADDED_HEAD:
-                k = tl.load(K_block_ptr, boundary_check=(1,0), padding_option="zero")
-            else:
-                k = tl.load(K_block_ptr, boundary_check=(1,), padding_option="zero")
-        else:
-            if PADDED_HEAD:
-                k = tl.load(K_block_ptr, boundary_check=(0,), padding_option="zero")
-            else:
-                k = tl.load(K_block_ptr)
+        k = load_fn(K_block_ptr, PADDED_HEAD, MASK_STEPS and (n_extra_tokens != 0), "zero")
         if PRE_LOAD_V:
-            if PADDED_BLOCK:
-                if PADDED_HEAD:
-                    v = tl.load(V_block_ptr, boundary_check=(0,1), padding_option="zero")
-                else:
-                    v = tl.load(V_block_ptr, boundary_check=(0,), padding_option="zero")
-            else:
-                if PADDED_HEAD:
-                    v = tl.load(V_block_ptr, boundary_check=(1,), padding_option="zero")
-                else:
-                    v = tl.load(V_block_ptr)
-        # -- compute qk ----
+            v = load_fn(V_block_ptr, MASK_STEPS and (n_extra_tokens != 0), PADDED_HEAD, "zero")
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-        if STAGE == 2:
-            mask = OFFS_M[:, None] >= (start_n + OFFS_N[None, :])
-            qk = tl.where(mask, qk, float("-inf"))
+        # We start from end of seqlen_k so only the first iteration would need
+        # to be checked for padding if it is not a multiple of block_n
+        # TODO: This can be optimized to only be true for the padded block.
+        if MASK_STEPS:
+            # If this is the last block / iteration, we want to
+            # mask if the sequence length is not a multiple of block size
+            # a solution is to always do BLOCK_M // BLOCK_N + 1 steps if not is_modulo_mn.
+            # last step might get wasted but that is okay. check if this masking works For
+            # that case.
+            if (start_n + BLOCK_N == block_max) and (n_extra_tokens != 0):
+                boundary_m = tl.full([BLOCK_M], actual_seqlen_k, dtype=tl.int32)
+                size_n = start_n + OFFS_N[None,:]
+                mask = size_n < boundary_m[:,None]
+                qk = tl.where(mask, qk, float("-inf"))
+        if IS_CAUSAL:
+            causal_boundary = start_n + offs_n_causal
+            causal_mask = OFFS_M[:, None] >= causal_boundary[None, :]
+            qk = tl.where(causal_mask, qk, float("-inf"))
+        # -- compute qk ----
         qk += tl.dot(q, k)
         if bias_ptr is not None:
-            if PADDED_BLOCK:
-                if bias_ptr.type.element_ty.is_block():
-                    bias = tl.load(bias_ptr,boundary_check=(1,), padding_option="zero")
-                else:
-                    size_n = start_n + OFFS_N
-                    boundary_n = tl.full([BLOCK_N], TOTAL_TOKENS, dtype=tl.float32)
-                    bias_padding = tl.full([BLOCK_N], 0, dtype=tl.float32)
-                    bias = tl.load(bias_ptr, mask=size_n < boundary_n, other=bias_padding)
-            else:
-                bias = tl.load(bias_ptr)
+            bias = load_fn(bias_ptr, False, MASK_STEPS and (n_extra_tokens != 0), "zero")
             # While bias is added after multiplying qk with sm_scale,
             # our optimization to use 2^x instead of e^x results in an additional
             # scale factor of log2(e) which we must also multiply the bias with.
             qk += (bias * 1.44269504089)
-        if PADDED_BLOCK:
-            boundary_m = tl.full([BLOCK_M], TOTAL_TOKENS, dtype=tl.float32)
-            size_n = start_n + OFFS_N[None,:]
-            mask = size_n < boundary_m[:,None]
-            qk = tl.where(mask, qk, float("-inf"))
-        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        m_ij = tl.maximum(m_i, tl.max(qk,1))
         qk = qk - m_ij[:, None]
         p = tl.math.exp2(qk)
+
         # CAVEAT: Must update l_ij before applying dropout
         l_ij = tl.sum(p, 1)
-        # Note about the conflicts of Flash attention algorithm and PyTorch's CUDA implementation
-        # PyTorch needs to return softmax(qk) (dropout mask encoded in sign bits)
-        # While Flash attention paper compute the dropout AFTER exp2(qk- m_ij)
         if ENABLE_DROPOUT:
-            philox_offset = batch_philox_offset + start_m * BLOCK_M * seqlen_k + start_n
-            keep = dropout_mask(philox_seed, philox_offset, dropout_p, BLOCK_M, BLOCK_N, seqlen_k)
+            philox_offset = batch_philox_offset + start_m * BLOCK_M * actual_seqlen_k + start_n - BLOCK_N
+            keep = dropout_mask(philox_seed, philox_offset, dropout_p, BLOCK_M, BLOCK_N, actual_seqlen_k)
             if RETURN_ENCODED_SOFTMAX:
                 tl.store(encoded_softmax_block_ptr, tl.where(keep, p, -p).to(encoded_softmax_block_ptr.type.element_ty))
             p = tl.where(keep, p, 0.0)
@@ -272,13 +218,7 @@ def _attn_fwd_inner(
         alpha = tl.math.exp2(m_i - m_ij)
         acc = acc * alpha[:, None]
         if not PRE_LOAD_V:
-            if PADDED_BLOCK:
-                if PADDED_HEAD:
-                    v = tl.load(V_block_ptr, boundary_check=(0,1), padding_option="zero")
-                else:
-                    v = tl.load(V_block_ptr, boundary_check=(0,), padding_option="zero")
-            else:
-                v = tl.load(V_block_ptr)
+            v = load_fn(V_block_ptr, MASK_STEPS and (n_extra_tokens != 0), PADDED_HEAD, "zero")
         # -- update m_i and l_i
         l_i = l_i * alpha + l_ij
         # update m_i and l_i
@@ -287,17 +227,29 @@ def _attn_fwd_inner(
         V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
         K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
         if bias_ptr is not None:
-            if bias_ptr.type.element_ty.is_block():
-                bias_ptr = tl.advance(bias_ptr, (0, BLOCK_N))
-            else:
-                bias_ptr += BLOCK_N
+            bias_ptr = tl.advance(bias_ptr, (0, BLOCK_N))
         if RETURN_ENCODED_SOFTMAX:
             encoded_softmax_block_ptr = tl.advance(encoded_softmax_block_ptr, (0, BLOCK_N))
     return acc, l_i, m_i
 
+@triton.autotune(
+   configs=[
+       triton.Config({'BLOCK_M': 256, 'BLOCK_N': 64, 'waves_per_eu': 2, 'PRE_LOAD_V': False}, num_stages=1, num_warps=8),
+       triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'waves_per_eu': 2, 'PRE_LOAD_V': False}, num_stages=1, num_warps=4),
+       triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'waves_per_eu': 2, 'PRE_LOAD_V': False}, num_stages=1, num_warps=8),
+       triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'waves_per_eu': 3, 'PRE_LOAD_V': True}, num_stages=1, num_warps=4),
+       triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'waves_per_eu': 3, 'PRE_LOAD_V': False}, num_stages=1, num_warps=4),
+       triton.Config({'BLOCK_M': 64, 'BLOCK_N': 64, 'waves_per_eu': 4, 'PRE_LOAD_V': False}, num_stages=1, num_warps=8),
+       triton.Config({'BLOCK_M': 32, 'BLOCK_N': 32, 'waves_per_eu': 4, 'PRE_LOAD_V': False}, num_stages=1, num_warps=8),
+       # TODO: This config fails with head_size not pow2 with data mismatches. Check why.
+    #    triton.Config({'BLOCK_M': 32, 'BLOCK_N': 16, 'waves_per_eu': 1, 'PRE_LOAD_V': False}, num_stages=1, num_warps=4),
+       triton.Config({'BLOCK_M': 16, 'BLOCK_N': 16, 'waves_per_eu': 1, 'PRE_LOAD_V': False}, num_stages=1, num_warps=4),
+   ],
+   key=['hq', 'hk', 'IS_CAUSAL', 'dropout_p', 'BLOCK_DMODEL'],
+)
 @triton.jit
 def attn_fwd(
-    Q, K, V, bias, sm_scale, M, Out,
+    Q, K, V, bias, sm_scale, L, Out,
     stride_qz, stride_qh, stride_qm, stride_qk,
     stride_kz, stride_kh, stride_kn, stride_kk,
     stride_vz, stride_vh, stride_vk, stride_vn,
@@ -310,9 +262,9 @@ def attn_fwd(
     encoded_softmax,
     actual_block_dmodel,
     max_seqlens_q, max_seqlens_k,
-    VARLEN: tl.constexpr,
     hq, hk,
-    STAGE: tl.constexpr,
+    VARLEN: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -321,11 +273,11 @@ def attn_fwd(
     ENABLE_DROPOUT: tl.constexpr,
     RETURN_ENCODED_SOFTMAX: tl.constexpr
 ):
-    is_mqa = hq != hk
     start_m = tl.program_id(0)
     off_h_q = tl.program_id(1)
     off_z = tl.program_id(2)
-    padded_head = (actual_block_dmodel == BLOCK_DMODEL)
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
     if VARLEN:
         cu_seqlens_q_start = tl.load(cu_seqlens_q + off_z)
         cu_seqlens_q_end = tl.load(cu_seqlens_q + off_z + 1)
@@ -342,20 +294,63 @@ def attn_fwd(
         cu_seqlens_k_start = 0
         seqlen_q = max_seqlens_q
         seqlen_k = max_seqlens_k
-    #off_h_k = off_h_q % hk if is_mqa else off_h_q
-    if is_mqa:
-        off_h_k = off_h_q % hk
-    else:
-        off_h_k = off_h_q
+
+    # Now we compute whether we need to exit early due to causal masking.
+    # This is because for seqlen_q > seqlen_k, M rows of the attn scores
+    # are completely masked, resulting in 0s written to the output, and
+    # inf written to LSE. We don't need to do any GEMMs in this case.
+    # This block of code determines what N is, and if this WG is operating
+    # on those M rows.
+    n_blocks = cdiv_fn(seqlen_k, BLOCK_N)
+    if (IS_CAUSAL):
+        # If seqlen_q == seqlen_k, the attn scores are a square matrix.
+        # If seqlen_q != seqlen_k, attn scores are rectangular which means
+        # the causal mask boundary is bottom right aligned, and ends at either
+        # the top edge (seqlen_q < seqlen_k) or left edge.
+        # This captures the decrease in n_blocks if we have a rectangular attn matrix
+        n_blocks_seqlen = cdiv_fn(
+            (start_m + 1) * BLOCK_M + seqlen_k - seqlen_q,
+            BLOCK_N
+        )
+        # This is what adjusts the block_max for the current WG, only
+        # if IS_CAUSAL. Otherwise we want to always iterate through all n_blocks
+        n_blocks = min(n_blocks, n_blocks_seqlen)
+        # If we have no blocks after adjusting for seqlen deltas, this WG is part of
+        # the blocks that are all 0. We exit early.
+        if n_blocks <= 0:
+            o_offset = off_z * stride_oz + cu_seqlens_q_start * stride_om + off_h_q * stride_oh
+            O_block_ptr = tl.make_block_ptr(
+                base=Out + o_offset,
+                shape=(seqlen_q, BLOCK_DMODEL),
+                strides=(stride_om, stride_on),
+                offsets=(start_m * BLOCK_M, 0),
+                block_shape=(BLOCK_M, BLOCK_DMODEL),
+                order=(1, 0)
+            )
+            acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=Out.type.element_ty)
+            # We still need to write 0s to the result
+            tl.store(O_block_ptr, acc.to(Out.type.element_ty), boundary_check=(0,1))
+            l_ptrs = L + off_z * hq * max_seqlens_q + off_h_q * max_seqlens_q + offs_m
+            # We store inf to LSE, not -inf because in the bwd pass, we subtract this
+            # from qk which makes it -inf, such that exp(qk - inf) = 0 for these masked blocks.
+            l = tl.full([BLOCK_M], value=float("inf"), dtype=tl.float32)
+            tl.store(l_ptrs, l)
+            # TODO: Should dropout and return encoded softmax be handled here too?
+            return
+
+    is_mqa = hq != hk
+    off_h_k = off_h_q % hk if is_mqa else off_h_q
     need_padding = False
-    extra_tokens_n = 0
+    n_extra_tokens = 0
     if seqlen_k < BLOCK_N:
         need_padding = True
-        extra_tokens_n = BLOCK_N - seqlen_k
+        n_extra_tokens = BLOCK_N - seqlen_k
     elif seqlen_k % BLOCK_N:
         need_padding = True
-        extra_tokens_n = seqlen_k % BLOCK_N
+        n_extra_tokens = seqlen_k % BLOCK_N
+    padded_head = (actual_block_dmodel != BLOCK_DMODEL)
 
+    # Compute pointers for all the tensors used in this kernel.
     q_offset = off_z * stride_qz +  off_h_q * stride_qh + cu_seqlens_q_start * stride_qm
     Q_block_ptr = tl.make_block_ptr(
         base=Q + q_offset,
@@ -383,40 +378,17 @@ def attn_fwd(
         block_shape=(BLOCK_N, BLOCK_DMODEL),
         order=(1, 0)
     )
-    # initialize offsets
-    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_n = tl.arange(0, BLOCK_N)
     if BIAS_TYPE != 0:
-        if BIAS_TYPE == 1:
-            bias_ptr = bias + off_h_q * stride_bh + offs_n
-        elif BIAS_TYPE == 2:
-            bias_ptr = tl.make_block_ptr(
-                base=bias + off_h_q * stride_bh,
-                shape=(seqlen_q, seqlen_k),
-                strides=(stride_bm, stride_bn),
-                offsets=(start_m * BLOCK_M, 0),
-                block_shape=(BLOCK_M, BLOCK_N),
-                order=(1, 0),
-            )
+        bias_ptr = tl.make_block_ptr(
+            base=bias + off_h_q * stride_bh,
+            shape=(seqlen_q, seqlen_k),
+            strides=(stride_bm, stride_bn),
+            offsets=(start_m * BLOCK_M, 0),
+            block_shape=(BLOCK_M, BLOCK_N),
+            order=(1, 0),
+        )
     else:
         bias_ptr = None
-    # initialize pointer to m and l
-    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
-    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
-    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
-    # scale sm_scale by log_2(e) and use
-    # 2^x instead of exp in the loop because CSE and LICM
-    # don't work as expected with `exp` in the loop
-    qk_scale = sm_scale * 1.44269504089
-    # load q: it will stay in SRAM throughout on NV GPUs but in VGPRs on AMD GPUs
-    if actual_block_dmodel == BLOCK_DMODEL:#padded_head:
-        q = tl.load(Q_block_ptr, boundary_check=(0,), padding_option="zero")
-    else:
-        q = tl.load(Q_block_ptr, boundary_check=(0,1), padding_option="zero")
-    q = (q * qk_scale).to(Q_block_ptr.type.element_ty)
-    # stage 1: off-band
-    # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
-    # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
     if ENABLE_DROPOUT:
         batch_philox_offset = philox_offset_base + off_hz * seqlen_q * seqlen_k
     else:
@@ -435,73 +407,105 @@ def attn_fwd(
                 )
     else:
         encoded_softmax_block_ptr = 0
-    if STAGE & 1:
-        # equal to N_CTX if N_CTX is already a multiple of block_M
-        seqlen_aligned = seqlen_k - extra_tokens_n
-        if seqlen_k >= BLOCK_N:
-            acc, l_i, m_i = _attn_fwd_inner(
-                acc, l_i, m_i, q, K_block_ptr, V_block_ptr,
-                start_m, seqlen_aligned,
-                dropout_p, philox_seed, batch_philox_offset, encoded_softmax_block_ptr,
-                BLOCK_M, BLOCK_DMODEL, BLOCK_N,
-                4 - STAGE, offs_m, offs_n,
-                PRE_LOAD_V,
-                False, seqlen_aligned,
-                padded_head,
-                bias_ptr,
-                ENABLE_DROPOUT,
-                RETURN_ENCODED_SOFTMAX
-            )
-        tl.debug_barrier()
-        if need_padding:
-            if seqlen_k < BLOCK_N:
-                seqlen_aligned = 0
-            acc, l_i, m_i = _attn_fwd_inner(
-                acc, l_i, m_i, q, K_block_ptr, V_block_ptr,
-                start_m, seqlen_aligned,
-                dropout_p, philox_seed, batch_philox_offset, encoded_softmax_block_ptr,
-                BLOCK_M, BLOCK_DMODEL, BLOCK_N,
-                4 - STAGE, offs_m, offs_n,
-                PRE_LOAD_V,
-                True, seqlen_k,
-                padded_head,
-                bias_ptr,
-                ENABLE_DROPOUT,
-                RETURN_ENCODED_SOFTMAX
-            )
-    # stage 2: on-band
-    if STAGE & 2:
-        # barrier makes it easier for compielr to schedule the
-        # two loops independently
-        tl.debug_barrier()
+    # initialize pointer to m and l
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # scale sm_scale by log_2(e) and use 2^x in the loop as we do not
+    # have native e^x support in HW.
+    qk_scale = sm_scale * 1.44269504089
+    # Q is loaded once at the beginning and shared by all N blocks.
+    q = load_fn(Q_block_ptr, True, padded_head, "zero")
+    q = (q * qk_scale).to(Q_block_ptr.type.element_ty)
+
+    # Here we compute how many full and masked blocks we have.
+    padded_block_k = n_extra_tokens != 0
+    is_modulo_mn = not padded_block_k and (seqlen_q % BLOCK_M == 0)
+    if IS_CAUSAL:
+        # There are always at least BLOCK_M // BLOCK_N masked blocks.
+        # Additionally there might be one more due to dissimilar seqlens.
+        masked_blocks = BLOCK_M // BLOCK_N + (not is_modulo_mn)
+    else:
+        # Padding on Q does not need to be masked in the FA loop.
+        masked_blocks = padded_block_k
+    # if IS_CAUSAL, not is_modulo_mn does not always result in an additional block.
+    # In this case we might exceed n_blocks so pick the min.
+    masked_blocks = min(masked_blocks, n_blocks)
+    n_full_blocks = n_blocks - masked_blocks
+    block_min = 0
+    block_max = n_blocks * BLOCK_N
+    # Compute for full blocks. Here we set causal to false regardless of its actual
+    # value because there is no masking. Similarly we do not need padding.
+    if n_full_blocks > 0:
+        block_max = (n_blocks - masked_blocks) * BLOCK_N
         acc, l_i, m_i = _attn_fwd_inner(
             acc, l_i, m_i, q, K_block_ptr, V_block_ptr,
             start_m, seqlen_k,
             dropout_p, philox_seed, batch_philox_offset, encoded_softmax_block_ptr,
-            BLOCK_M, BLOCK_DMODEL, BLOCK_N,
-            2, offs_m, offs_n,
-            PRE_LOAD_V,
-            False, seqlen_aligned,
-            padded_head,
-            bias_ptr,
-            ENABLE_DROPOUT,
-            RETURN_ENCODED_SOFTMAX
+            # _, _, offs_n_causal, masked_blocks, n_extra_tokens, _
+            block_min, block_max, 0, 0, 0, bias_ptr,
+            # IS_CAUSAL, ....
+            False, BLOCK_M, BLOCK_DMODEL, BLOCK_N, offs_m, offs_n,
+            # _, MASK_STEPS, ...
+            PRE_LOAD_V, False, ENABLE_DROPOUT, RETURN_ENCODED_SOFTMAX, padded_head
+        )
+        block_min = block_max
+        block_max = n_blocks * BLOCK_N
+
+    tl.debug_barrier()
+    # Remaining blocks, if any, are full / not masked.
+    if (masked_blocks > 0):
+        if IS_CAUSAL:
+            offs_n_causal = offs_n + (seqlen_q - seqlen_k)
+        else:
+            offs_n_causal = 0
+        K_block_ptr = tl.advance(K_block_ptr, (0, n_full_blocks*BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (n_full_blocks*BLOCK_N, 0))
+        if bias_ptr is not None:
+            bias_ptr = tl.advance(bias_ptr, (0, n_full_blocks*BLOCK_N))
+        if RETURN_ENCODED_SOFTMAX:
+            encoded_softmax_block_ptr = tl.advance(encoded_softmax_block_ptr,
+                                                   (0, n_full_blocks))
+        acc, l_i, m_i = _attn_fwd_inner(
+            acc, l_i, m_i, q, K_block_ptr, V_block_ptr,
+            start_m, seqlen_k,
+            dropout_p, philox_seed, batch_philox_offset, encoded_softmax_block_ptr,
+            block_min, block_max, offs_n_causal, masked_blocks,  n_extra_tokens, bias_ptr,
+            IS_CAUSAL, BLOCK_M, BLOCK_DMODEL, BLOCK_N, offs_m, offs_n,
+            # _, MASK_STEPS, ...
+            PRE_LOAD_V, True, ENABLE_DROPOUT, RETURN_ENCODED_SOFTMAX, padded_head
         )
     # epilogue
-    # write back m
     acc = acc / l_i[:, None]
     if ENABLE_DROPOUT:
         acc = acc / (1 - dropout_p)
-    m_ptrs = M + off_z * hq * max_seqlens_q + off_h_q * max_seqlens_q + offs_m
-    # Check for last block_M
-    overflow_size = (start_m * BLOCK_M) - seqlen_q
+    # If seqlen_q > seqlen_k but the delta is not a multiple of BLOCK_M,
+    # then we have one block with a row of all NaNs which come from computing
+    # softmax over a row of all -infs (-inf - inf = NaN). We check for that here
+    # and store 0s where there are NaNs as these rows should've been zeroed out.
+    end_m_idx = (start_m + 1) * BLOCK_M
+    start_m_idx = start_m * BLOCK_M
+    causal_start_idx = seqlen_q - seqlen_k
+    acc = acc.to(Out.type.element_ty)
+    if IS_CAUSAL:
+        if causal_start_idx > start_m_idx and causal_start_idx < end_m_idx:
+            out_mask_boundary = tl.full((BLOCK_DMODEL,), causal_start_idx, dtype=tl.int32)
+            mask_m_offsets = start_m_idx + tl.arange(0, BLOCK_M)
+            out_ptrs_mask = mask_m_offsets[:, None] >= out_mask_boundary[None, :]
+            acc = tl.where(out_ptrs_mask, acc, 0)
+    # write back LSE
+    l_ptrs = L + off_z * hq * max_seqlens_q + off_h_q * max_seqlens_q + offs_m
+    # If seqlen_q not multiple of BLOCK_M, we need to mask out the last few rows.
+    # This is only true for the last M block. For others, overflow_size will be -ve
+    overflow_size = end_m_idx - seqlen_q
     if overflow_size > 0:
-        boundary = tl.full((BLOCK_M,), overflow_size, dtype=tl.float32)
+        boundary = tl.full((BLOCK_M,), BLOCK_M - overflow_size, dtype=tl.int32)
         # This is a > check because mask being 0 blocks the store.
-        m_ptrs_mask = boundary > tl.arange(0, BLOCK_M)
-        tl.store(m_ptrs, m_i + tl.math.log2(l_i), mask=m_ptrs_mask)
+        l_ptrs_mask = boundary > tl.arange(0, BLOCK_M)
+        tl.store(l_ptrs, m_i + tl.math.log2(l_i), mask=l_ptrs_mask)
     else:
-        tl.store(m_ptrs, m_i + tl.math.log2(l_i))
+        tl.store(l_ptrs, m_i + tl.math.log2(l_i))
+
     # write back O
     o_offset = off_z * stride_oz + cu_seqlens_q_start * stride_om + off_h_q * stride_oh
     O_block_ptr = tl.make_block_ptr(
@@ -512,7 +516,10 @@ def attn_fwd(
         block_shape=(BLOCK_M, BLOCK_DMODEL),
         order=(1, 0)
     )
-    tl.store(O_block_ptr, acc.to(Out.type.element_ty), boundary_check=(0,1))# Don't exceed shape, makes sure padding isn't put in output.
+    # Need boundary check on this to make sure the padding from the
+    # Q and KV tensors in both dims are not part of what we store back.
+    # TODO: Do the boundary check optionally.
+    tl.store(O_block_ptr, acc, boundary_check=(0,1))
 
 @triton.jit
 def _attn_bwd_preprocess(O, DO,  #
@@ -810,15 +817,9 @@ class _attention(torch.autograd.Function):
         else:
             padded_d_model = head_size
 
-        # We've derived these previously from tuning the kernel
-        # TODO: Add autotuning
-        BLOCK_M = 256
-        BLOCK_N = 128 if head_size == 128 else 64
-        waves_per_eu = 2 if head_size == 128 else 3
-        num_warps = 8 if head_size == 128 else 4
-        pre_load_v = False if head_size == 128 else True
-        grid = (
-            triton.cdiv(metadata.max_seqlens_q, BLOCK_M),
+
+        grid = lambda META: (
+            triton.cdiv(metadata.max_seqlens_q, META['BLOCK_M']),
             nheads_q,
             batch
         )
@@ -832,15 +833,13 @@ class _attention(torch.autograd.Function):
         else:
             encoded_softmax = None
 
-        stage = 3 if metadata.causal else 1
-
         M = torch.empty((batch, nheads_q, metadata.max_seqlens_q), device=q.device, dtype=torch.float32)
 
         # Seed the RNG so we get reproducible results for testing.
         philox_seed = 0x1BF52
         philox_offset = 0x1D4B42
 
-        if metadata.bias_type != 0:
+        if metadata.bias is not None:
             bias_strides = (metadata.bias.stride(0), metadata.bias.stride(1),
                             metadata.bias.stride(2), metadata.bias.stride(3))
         else:
@@ -857,15 +856,13 @@ class _attention(torch.autograd.Function):
             actual_block_dmodel=head_size,
             max_seqlens_q=metadata.max_seqlens_q,
             max_seqlens_k=metadata.max_seqlens_k,
-            VARLEN=metadata.varlen,
             hq=nheads_q, hk=nheads_k,
-            STAGE=stage,
-            BLOCK_M=BLOCK_M, BLOCK_DMODEL=padded_d_model, BLOCK_N=BLOCK_N,
-            PRE_LOAD_V=pre_load_v,
-            BIAS_TYPE=metadata.bias_type,
+            IS_CAUSAL=metadata.causal,
+            VARLEN=metadata.varlen,
+            BLOCK_DMODEL=padded_d_model,
+            BIAS_TYPE=0 if metadata.bias is None else 1,
             ENABLE_DROPOUT=metadata.dropout_p > 0.0,
-            RETURN_ENCODED_SOFTMAX=metadata.return_encoded_softmax,
-            num_stages=1, num_warps=num_warps
+            RETURN_ENCODED_SOFTMAX=metadata.return_encoded_softmax
         )
 
         ctx.save_for_backward(q, k, v, o, M)
@@ -951,58 +948,45 @@ class _attention(torch.autograd.Function):
 
 attention = _attention.apply
 
-@pytest.mark.parametrize('Z, H, N_CTX, D_HEAD',
-                         [(4, 48, 63, 64),
-                          (4, 48, 987, 64),
-                          (4, 48, 2048, 64),
-                          (4, 48, 4096, 64),
-                          (4, 48, 3989, 64),
-                          (4, 48, 1024, 128),
-                          (4, 48, 1021, 128),
-                          (4, 48, 2048, 128),
-                          (4, 48, 4096, 128),
-                          (4, 16, 8192, 64),
-                          (4, 16, 8080, 64),
-                          (1, 16, 16384, 64),
-                          (4, 48, 127, 64),
-                          (4, 4, 128, 33),
-                          (4, 4, 65, 65),
-                          (4, 4, 113, 90),
-                          (4, 4, 113, 1),
+@pytest.mark.parametrize('Z, H, N_CTX_Q, N_CTX_K, D_HEAD',
+                         [(4, 48, 1024, 1024, 64),
+                          (4, 48, 8192, 8192, 64),
+                          (2, 16, 16384, 16384, 128),
+                          (2, 16, 1020, 987, 128),
+                          (2, 16, 15498, 2, 128),
+                          (2, 16, 7, 16219, 64),
+                          (4, 48, 1, 1, 64),
+                          (4, 48, 1, 1, 128),
+                          (4, 48, 3, 3, 128),
+                          (4, 48, 1001, 990, 64),
+                          (1, 8, 8081, 7099, 64),
+                          (1, 8, 16330, 15989, 128),
+                          (4, 4, 1024, 1024, 33),
+                          (4, 4, 65, 1019, 65),
+                          (4, 4, 128, 128, 65),
+                          (4, 4, 113, 123, 1),
                           ])
 @pytest.mark.parametrize('causal', [False, True])
-@pytest.mark.parametrize('use_bias', [False, True])
-@pytest.mark.parametrize('bias_type', ["vector", "matrix"])
-@pytest.mark.parametrize('qseqlen_not_equal_kseqlen', [512, None]) #dropout needs to be tested vs SPDA reference in torch
-def test_op_fwd(Z, H, N_CTX, D_HEAD, causal, use_bias, bias_type, qseqlen_not_equal_kseqlen, dtype=torch.float16):
+@pytest.mark.parametrize('use_bias', [False])
+def test_op_fwd(Z, H, N_CTX_Q, N_CTX_K, D_HEAD, causal, use_bias, dtype=torch.float16):
     # TODO: using bias causes coredump for certain configs and must be fixed.
     if use_bias:
         pytest.skip()
-    if causal and ((N_CTX - 1) & N_CTX):
-        pytest.skip()
     torch.manual_seed(20)
-    if qseqlen_not_equal_kseqlen is not None:
-        seqlen_q = qseqlen_not_equal_kseqlen
-    else:
-        seqlen_q = N_CTX
-    seqlen_k = N_CTX
     sm_scale = D_HEAD ** -0.5
     input_metadata = MetaData(sm_scale=sm_scale)
-    input_metadata.max_seqlens_q = seqlen_q
-    input_metadata.max_seqlens_k = seqlen_k
+    input_metadata.max_seqlens_q = N_CTX_Q
+    input_metadata.max_seqlens_k = N_CTX_K
     if causal:
         input_metadata.need_causal()
     if use_bias:
-        if bias_type == "vector":
-            bias = torch.randn((1, H, 1, seqlen_k), dtype=torch.float32, device="cuda")
-        elif bias_type == "matrix":
-            bias = torch.randn((1, H, seqlen_q, seqlen_k), dtype=torch.float32, device="cuda")
-        input_metadata.need_bias(bias, Z, H, seqlen_q, seqlen_k)
+        bias = torch.randn((1, H, N_CTX_Q, N_CTX_K), dtype=torch.float32, device="cuda")
+        input_metadata.need_bias(bias, Z, H, N_CTX_Q, N_CTX_K)
     else:
         bias = None
-    q = torch.randn((Z, H, seqlen_q, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
-    k = torch.randn((Z, H, seqlen_k, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
-    v = torch.randn((Z, H, seqlen_k, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
+    q = torch.randn((Z, H, N_CTX_Q, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
+    k = torch.randn((Z, H, N_CTX_K, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
+    v = torch.randn((Z, H, N_CTX_K, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0., std=0.5).requires_grad_()
     if TORCH_HAS_FP8E5:
         q = q.to(torch_dtype)
         k = k.to(torch_dtype)
@@ -1010,15 +994,23 @@ def test_op_fwd(Z, H, N_CTX, D_HEAD, causal, use_bias, bias_type, qseqlen_not_eq
 
     # triton implementation
     tri_out, _ = attention(q, k, v, o, input_metadata)
-    # reference implementation
-    M = torch.tril(torch.ones((seqlen_q, seqlen_k), device="cuda"))
+    # reference implementation:171
+
     scores = torch.einsum('bhqd,bhkd->bhqk', q, k).float() * sm_scale
     if causal:
-        scores[:, :, M == 0] = float("-inf")
+        mask = torch.tril(torch.ones(N_CTX_Q, N_CTX_K, device="cuda"),
+                          diagonal=N_CTX_K-N_CTX_Q)
+        scores[:, :, mask==0] = float("-inf")
     if use_bias:
         scores += input_metadata.bias
-    p = torch.softmax(scores.float(), dim=-1).half()
-    ref_out = torch.matmul(p, v)
+    p = torch.softmax(scores, dim=-1)
+    if causal:
+        # If N_CTX_Q > N_CTX_K, there is at least one row of all -infs going into
+        # the softmax. This produces a row of NaNs as -inf - -inf == NaN. So we fix
+        # this by converting the NaNs to 0s, which is what they should be out of the softmax.
+        nan_mask = torch.isnan(p)
+        p[nan_mask==1] = 0
+    ref_out = torch.einsum('bhqk,bhkd->bhqd', p.half(), v)
     # compare
     torch.testing.assert_close(ref_out, tri_out, atol=2e-2, rtol=2e-2)
 
@@ -1066,7 +1058,7 @@ def varlen_input_helper(Z, HQ, HK, N_CTX, D_HEAD, dtype):
                           (4, 16, 8192, 128),
                           (32, 48, 8192, 128)
                           ])
-@pytest.mark.parametrize('causal', [False])
+@pytest.mark.parametrize('causal', [True, False])
 def test_op_varlen_fwd(Z, H, N_CTX, D_HEAD, causal, dtype=torch.float16):
     q, k, v, input_metadata = varlen_input_helper(Z, H, H, N_CTX, D_HEAD, dtype)
     tri_out = torch.empty_like(q)
@@ -1098,8 +1090,8 @@ def test_op_varlen_fwd(Z, H, N_CTX, D_HEAD, causal, dtype=torch.float16):
 @pytest.mark.parametrize('causal', [False])
 def test_op_varlen_mqa_fwd(Z, HQ, HK, N_CTX, D_HEAD, causal, dtype=torch.float16):
     q, k, v, input_metadata = varlen_input_helper(Z, HQ, HK, N_CTX, D_HEAD, dtype)
-    tri_out = torch.full_like(q, float("nan"))
-    ref_out = torch.full_like(q, float("nan"))
+    ref_out = torch.empty_like(q)
+    tri_out = torch.empty_like(q)
     # Make KV look like HQ/HK "groups" of HK. Later, we will reshape so the
     # size aligns with Q.
     k_ref = k.view(k.shape[0], 1, k.shape[1], k.shape[2]).expand(-1, HQ // HK, -1, -1)
@@ -1111,7 +1103,7 @@ def test_op_varlen_mqa_fwd(Z, HQ, HK, N_CTX, D_HEAD, causal, dtype=torch.float16
         k_curr = k_curr.reshape(k_curr.shape[0], -1, k_curr.shape[3])
         v_curr = v_ref[start_k:end_k]
         v_curr = v_curr.reshape(v_curr.shape[0], -1, v_curr.shape[3])
-        scores = torch.einsum('qhd,khd->qhk', q_curr[start_q:end_q], k_curr).float()
+        scores = torch.einsum('qhd,khd->qhk', q[start_q:end_q], k_curr).float()
         p = torch.softmax(scores * input_metadata.sm_scale, dim=-1).half()
         ref_out[start_q:end_q] = torch.einsum('qhk,khd->qhd', p, v_curr)
     attention(q, k, v, tri_out, input_metadata)
@@ -1173,74 +1165,70 @@ for mode in ['fwd']:
     for D_HEAD in [128]:
         if mode == 'bwd' and D_HEAD == 128:
             continue
-        for causal in [False]:
+        for causal in [False, True]:
             if mode == 'bwd' and causal == False:
                 continue
-            for use_bias in [False, True]:
-                configs.append(triton.testing.Benchmark(
-                    x_names=['BATCH', 'H','N_CTX'],
-                    x_vals=[(16, 16, 1024),
-                            (8, 16, 2048),
-                            (4, 16, 4096),
-                            (2, 16, 8192),
-                            (1, 16, 16384),
-                            (2, 48, 1024),
-                            (2, 48, 2048),
-                            (2, 48, 4096),
-                            (2, 48, 8192),
-                            (2, 48, 16384),
-                            (8, 16, 1989),
-                            (4, 16, 4097),
-                            (2, 16, 8122),
-                            (1, 16, 16281),
-                            (2, 48, 1021),
-                            (2, 48, 2001),
-                            (2, 48, 3996),
-                            (2, 48, 8181),
-                            ],
-                    line_arg='provider',
-                    line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
-                    line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []),
-                    styles=[('red', '-'), ('blue', '-')],
-                    ylabel='ms',
-                    plot_name=f'fused-attention-{mode}-d{D_HEAD}-causal={causal}-bias={use_bias}',
-                    args={
-                        'D_HEAD': D_HEAD,
-                        'dtype': torch.float16,
-                        'mode': mode,
-                        'causal': causal,
-                        'use_bias' : use_bias})
-                )
+            configs.append(triton.testing.Benchmark(
+                x_names=['BATCH', 'H', 'N_CTX_Q', 'N_CTX_K'],
+                x_vals=[(16, 16, 1024, 1024),
+                        # (8, 16, 2048, 2048),
+                        # (4, 16, 4096, 4096),
+                        # (2, 16, 8192, 8192),
+                        # (1, 16, 16384, 16384),
+                        # (2, 48, 1024, 1024),
+                        # (2, 48, 2048, 1024),
+                        # (2, 48, 4096, 8192),
+                        # (2, 48, 8192, 4096),
+                        # (2, 48, 16384, 8192),
+                        # (8, 16, 1989, 15344),
+                        # (4, 16, 4097, 163),
+                        # (2, 16, 8122, 2159),
+                        # (1, 16, 16281, 7),
+                        # (2, 48, 1021, 1020),
+                        # (2, 48, 2001, 2048),
+                        # (2, 48, 3996, 9639),
+                        # (2, 48, 8181, 1021),
+                        ],
+                line_arg='provider',
+                line_vals=['triton'] + (['flash'] if HAS_FLASH else []),
+                line_names=['Triton'] + ([f'Flash-{FLASH_VER}'] if HAS_FLASH else []),
+                styles=[('red', '-'), ('blue', '-')],
+                ylabel='ms',
+                plot_name=f'fused-attention-{mode}-d{D_HEAD}-causal={causal}',
+                args={
+                    'D_HEAD': D_HEAD,
+                    'dtype': torch.float16,
+                    'mode': mode,
+                    'causal': causal})
+            )
 @triton.testing.perf_report(configs)
 def bench_flash_attention(
-    BATCH, H, N_CTX, D_HEAD, use_bias, causal, mode, provider, dtype=torch.float16, device="cuda"
+    BATCH, H, N_CTX_Q, N_CTX_K, D_HEAD, causal, mode, provider, dtype=torch.float16, device="cuda"
 ):
     assert mode in ["fwd", "bwd"]
     warmup = 25
     rep = 100
-    split_kernel = False
     sm_scale = D_HEAD**-0.5
     input_metadata = MetaData(sm_scale=sm_scale)
-    input_metadata.max_seqlens_q = N_CTX
-    input_metadata.max_seqlens_k = N_CTX
-    bias_type = "vector"
-    if use_bias:
-        if bias_type == "vector":
-            bias = torch.randn((1, H, 1, N_CTX), dtype=torch.float32, device="cuda")
-        elif bias_type == "matrix":
-            bias = torch.randn((1, H, N_CTX, N_CTX), dtype=torch.float32, device="cuda")
-        input_metadata.need_bias(bias, BATCH, H, N_CTX, N_CTX)
-    else:
-        bias = None
+    input_metadata.max_seqlens_q = N_CTX_Q
+    input_metadata.max_seqlens_k = N_CTX_K
+    if causal:
+        input_metadata.need_causal()
+    # TODO: Enable bias after testing.
+    # if use_bias:
+    #     bias = torch.randn((1, H, N_CTX, N_CTX), dtype=torch.float32, device="cuda")
+    #     input_metadata.need_bias(bias, BATCH, H, N_CTX, N_CTX)
+    # else:
+    #     bias = None
+    bias = None
 
     # Bwd pass only supports causal=True right now
     if mode == 'bwd':
         causal = True
-        split_kernel = True
     if provider == "triton":
-        q = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
-        k = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
-        v = torch.randn((BATCH, H, N_CTX, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        q = torch.randn((BATCH, H, N_CTX_Q, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX_K, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
+        v = torch.randn((BATCH, H, N_CTX_K, D_HEAD), dtype=dtype, device="cuda", requires_grad=True)
         o = torch.empty_like(q)
         if mode == "fwd":
             q = q.to(torch_dtype)
@@ -1261,8 +1249,9 @@ def bench_flash_attention(
             do = torch.randn_like(o)
             fn = lambda: o.backward(do, retain_graph=True)
         ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
-    flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * D_HEAD
+    flops_per_matmul = 2.0 * BATCH * H * N_CTX_Q * N_CTX_K * D_HEAD
     total_flops = 2 * flops_per_matmul
+    # TODO: This needs to be fixed for unequal Q/K seqlens
     if causal:
         total_flops *= 0.5
     if mode == "bwd":

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -171,7 +171,7 @@ public:
 private:
   std::unique_ptr<mlir::OpBuilder> builder;
   std::unique_ptr<mlir::Location> lastLoc;
-  bool lineInfoEnabled = !triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO");
+  bool lineInfoEnabled = !mlir::triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO");
 };
 
 static std::string locationToString(mlir::Location loc) {
@@ -1737,7 +1737,7 @@ void init_triton_ir(py::module &&m) {
       .def(py::init<mlir::MLIRContext *>())
       .def("enable_debug",
            [](mlir::PassManager &self) {
-             if (!::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP"))
+             if (!mlir::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP"))
                return;
              self.getContext()->disableMultithreading();
              auto printingFlags = mlir::OpPrintingFlags();
@@ -1930,8 +1930,8 @@ void init_triton_ir(py::module &&m) {
 void init_triton_env_vars(py::module &m) {
   m.def("get_env_vars", []() -> std::map<std::string, bool> {
     std::map<std::string, bool> envVars;
-    for (const auto &envVar : triton::ENV_VARS) {
-      envVars[envVar] = triton::tools::getBoolEnv(envVar);
+    for (const auto &envVar : mlir::triton::ENV_VARS) {
+      envVars[envVar] = mlir::triton::tools::getBoolEnv(envVar);
     }
     return envVars;
   });
@@ -2068,7 +2068,7 @@ void init_triton_translation(py::module &m) {
             ofs.close();
 
             auto lineInfoOption =
-                triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO")
+                mlir::triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO")
                     ? ""
                     : " -lineinfo";
             auto fmadOption = enable_fp_fusion ? "" : " --fmad=false";


### PR DESCRIPTION
1) Added support for causal masking for MHA, MQA and GQA fwd kernel
2) Causal masking now works with dissimilar sequence lengths
3) Removed vector bias - this is unrelated, but is not needed and I did not want to keep maintaining unnecessary code
4) Couple other unrelated bugfixes found during code review.