### PR TITLE
Integrate cudagraph to autotuning 

### DIFF
--- a/python/perf-kernels/03-matrix-multiplication-all-types.py
+++ b/python/perf-kernels/03-matrix-multiplication-all-types.py
@@ -16,6 +16,7 @@ import re
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 32, 'waves_per_eu': 2}, num_warps=4, num_stages=0),
     ],
     key=['M', 'N', 'K'],
+    use_cuda_graph=True,
 )
 @triton.heuristics({
     'EVEN_K': lambda args: args['K'] % args['BLOCK_SIZE_K'] == 0,

--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -248,6 +248,7 @@ def _attn_fwd_inner(
        triton.Config({'BLOCK_M': 16, 'BLOCK_N': 16, 'waves_per_eu': 1, 'PRE_LOAD_V': False}, num_stages=1, num_warps=4),
    ],
    key=['hq', 'hk', 'IS_CAUSAL', 'dropout_p', 'BLOCK_DMODEL'],
+   use_cuda_graph=True,
 )
 @triton.jit
 def attn_fwd(

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -18,7 +18,8 @@ def nvsmi(attrs):
     return ret
 
 
-def do_bench_cudagraph(fn, rep=20, grad_to_none=None):
+def do_bench_cudagraph(fn, rep=20, grad_to_none=None, return_mode="mean"):
+    assert return_mode in ["min", "max", "mean", "median"]
     import torch
     """
     Benchmark the runtime of the provided function.
@@ -75,7 +76,8 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None):
         end_event.record()
         torch.cuda.synchronize()
         ret += [start_event.elapsed_time(end_event) / n_repeat]
-    return torch.mean(torch.tensor(ret)).item()
+    times = torch.tensor(ret)
+    return getattr(torch, return_mode)(times).item()
 
 
 def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean"):


### PR DESCRIPTION
This change is from the upstream PR https://github.com/openai/triton/pull/3306. Integrate the changes to this fork for more correct tuning results.