### PR TITLE
Enable fast-exp

### DIFF
--- a/python/triton/third_party/hip/hip_backend.py
+++ b/python/triton/third_party/hip/hip_backend.py
@@ -248,7 +248,7 @@ def get_amdgcn_bitcode_paths(gfx_arch: str):
                                            "ocml.bc",
                                            "ockl.bc",
                                            "oclc_finite_only_off.bc",
-                                           "oclc_daz_opt_off.bc",
+                                           "oclc_daz_opt_on.bc",
                                            "oclc_correctly_rounded_sqrt_on.bc",
                                            "oclc_unsafe_math_off.bc",
                                            "oclc_wavefrontsize64_on.bc",


### PR DESCRIPTION
By replace oclc_daz_opt_off.bc with *_on.bc, _exp2_f32() function will not perform the operand subnormal check and adjust the computation of exp.

@jtang10  Can you add you python code to explain the difference here?