### PR TITLE
[release/pytorch_2.2] Update required arguments for build scripts

### DIFF
--- a/scripts/amd/fix_so.sh
+++ b/scripts/amd/fix_so.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 #From https://github.com/pytorch/builder/blob/main/manywheel/build_common.sh
-WHEELHOUSE_DIR=/artifacts
+if [ -z "$1" ]; then
+    echo "Need wheel location argument" && exit 1
+fi
+
+WHEELHOUSE_DIR=$1
 PATCHELF_BIN=patchelf
 ROCM_LIB=third_party/hip/lib
 ROCM_LD=third_party/hip/llvm/bin

--- a/scripts/amd/setup_rocm_libs.sh
+++ b/scripts/amd/setup_rocm_libs.sh
@@ -4,8 +4,7 @@ set -ex
 
 # Check if ROCM_VERSION argument is provided
 if [[ -z "$1" ]]; then
-    echo "ROCM_VERSION argument not provided setting to default."
-    ROCM_VERSION="6.0"
+    echo "ROCM_VERSION argument not provided" && exit 1
 else
     ROCM_VERSION="$1"
 fi


### PR DESCRIPTION
* Make first argument to provide wheel location mandatory
* Make ROCM_VERSION argument mandatory for setup_rocm_libs.sh
(cherry picked from commit 4d510c3a44d23aacfbce21ed1b2853e8e09e9f90)