### PR TITLE
fix: replace if/else statement with tl.where

### DIFF
--- a/python/perf-kernels/flash-attention.py
+++ b/python/perf-kernels/flash-attention.py
@@ -335,7 +335,7 @@ def attn_fwd(
             return
 
     is_mqa = hq != hk
-    off_h_k = off_h_q % hk if is_mqa else off_h_q
+    off_h_k = tl.where(is_mqa, off_h_q % hk, off_h_q)
     need_padding = False
     n_extra_tokens = 0
     if seqlen_k < BLOCK_N:


### PR DESCRIPTION
While running the flash attention benchmark in a python environment, I encountered the following error
`    is_mqa = hq != hk`
`    off_h_k = off_h_q % hk if is_mqa else off_h_q`
`              ^`
`Triton does not support if expressions (ternary operators) with dynamic conditions, use `if` statements instead`

Version information
ROCm: 5.7.3
python: 3.11
Triton: pytorch-triton-rocm:       2.2.0 
System: MI250 (gfx90a)

Solution: Replaced the if/else statement with tl.where function. With this replacement, the benchmark runs without error message. 