### PR TITLE
Fix post-processing to exclude local_load and local_alloc

### DIFF
--- a/scripts/amd/occ.sh
+++ b/scripts/amd/occ.sh
@@ -64,6 +64,6 @@ perf=$(tail -n 2 output.mlir)
 echo "$perf"
 
 ## remove distracting info from the assembly
-sed -i '/\.loc/d' output.mlir
+sed -i '/local_/! {/\.loc/d}' output.mlir
 sed -i '/\.Ltmp.*:/d' output.mlir
 sed -i '/AMD clang version/d' output.mlir


### PR DESCRIPTION
Recently upstream introduced local_load and local_alloc ops, which fall into the delete list of occ.sh's post processing step. This PR fixes this issue so that we won't delete those two ops in the IR.