### PR TITLE
Increase CI timeout

### DIFF
--- a/.github/workflows/amd_perf_kernel_Integration_tests.yml
+++ b/.github/workflows/amd_perf_kernel_Integration_tests.yml
@@ -95,7 +95,7 @@ jobs:
     needs: Runner-Preparation-AMD
     if: needs.Runner-Preparation-AMD.outputs.matrix-HIP != ''
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       matrix:
         runner: ${{fromJson(needs.Runner-Preparation-AMD.outputs.matrix-HIP)}}

--- a/.github/workflows/amd_perf_kernel_postmerge_tests.yml
+++ b/.github/workflows/amd_perf_kernel_postmerge_tests.yml
@@ -36,7 +36,7 @@ jobs:
     needs: Runner-Preparation-AMD
     if: needs.Runner-Preparation-AMD.outputs.matrix-HIP != ''
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       matrix:
         runner: ${{fromJson(needs.Runner-Preparation-AMD.outputs.matrix-HIP)}}


### PR DESCRIPTION
Some new tests are taking too long and timing out the runner. This was triggered by increasing the autotuning keys for flash attention.