### PR TITLE
[release/internal/2.0] std::filesystem fix for gcc8 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 project(triton)
-link_libraries("-lstdc++fs")
+link_libraries( "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>" )
 include(CTest)
 if(NOT WIN32)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 project(triton)
+link_libraries("-lstdc++fs")
 include(CTest)
 if(NOT WIN32)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Required to build triton successfully using gcc8. Without this fix, the llvm static libraries built on gcc8 would have references to std::filesystem symbols which would show up as linker errors about undefined symbols when linking triton executables.
eg.
```
../lib/Target/LLVMIR/libTritonLLVMIR.a(LLVMIRTranslation.cpp.o): In function `mlir::triton::getExternLibs(mlir::ModuleOp)':
/usr/include/c++/8/bits/fs_ops.h:121: undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/include/c++/8/bits/fs_ops.h:121: undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
../lib/Target/LLVMIR/libTritonLLVMIR.a(LLVMIRTranslation.cpp.o): In function `mlir::triton::getExternLibs(mlir::ModuleOp)':
/usr/include/c++/8/bits/fs_path.h:185: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/include/c++/8/bits/fs_path.h:185: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/include/c++/8/bits/fs_path.h:185: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/include/c++/8/bits/fs_path.h:185: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
...
collect2: error: ld returned 1 exit status
gmake[2]: *** [bin/CMakeFiles/triton-translate.dir/build.make:486: bin/triton-translate] Error 1
```