### PR TITLE
[release/internal/3.8.x][AMD] Cherry-pick BarrierOpConversion CDNA restriction (#10906)

### DIFF
--- a/test/Conversion/amd/barrier_op_to_llvm.mlir
+++ b/test/Conversion/amd/barrier_op_to_llvm.mlir
@@ -1,0 +1,30 @@
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=TAGGED
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=TAGGED
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1100 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=GENERIC
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1200 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=RDNA4
+// RUN: triton-opt %s --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 --convert-builtin-func-to-llvm | FileCheck %s --check-prefix=TAGGED
+
+// RDNA targets fall back to the generic barrier lowering without MMRA tags.
+// TAGGED-DAG: [[$LOCAL_MMRA_TAG:#[A-Za-z0-9_]+]] = #llvm.mmra_tag<"amdgpu-synchronize-as":"local">
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // TAGGED-LABEL: llvm.func @lower_barrier
+  // GENERIC-LABEL: llvm.func @lower_barrier
+  // RDNA4-LABEL: llvm.func @lower_barrier
+  tt.func @lower_barrier() {
+    // TAGGED: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+    // TAGGED-NEXT: rocdl.s.barrier
+    // TAGGED-NEXT: llvm.fence syncscope("workgroup") acquire {llvm.mmra = [[$LOCAL_MMRA_TAG]]}
+
+    // GENERIC: llvm.fence syncscope("workgroup") release{{$}}
+    // GENERIC-NEXT: rocdl.s.barrier
+    // GENERIC-NEXT: llvm.fence syncscope("workgroup") acquire{{$}}
+
+    // RDNA4: llvm.fence syncscope("workgroup") release{{$}}
+    // RDNA4-NEXT: rocdl.s.barrier.signal id = -1
+    // RDNA4-NEXT: rocdl.s.barrier.wait id = -1
+    // RDNA4-NEXT: llvm.fence syncscope("workgroup") acquire{{$}}
+    ttg.barrier local
+    tt.return
+  }
+}

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -1,7 +1,6 @@
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s --enable-var-scope --check-prefixes=CHECK,COMMON
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s --enable-var-scope --check-prefixes=GFX950,COMMON
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 | FileCheck %s --enable-var-scope --check-prefixes=GFX1250,COMMON
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx906 | FileCheck %s --enable-var-scope --check-prefixes=GFX906,COMMON
 
 // COMMON-DAG: [[$LOCAL_MMRA_TAG:#[A-Za-z0-9_]+]] = #llvm.mmra_tag<"amdgpu-synchronize-as":"local">
 // COMMON-DAG: [[$GLOBAL_MMRA_TAG:#[A-Za-z0-9_]+]] = #llvm.mmra_tag<"amdgpu-synchronize-as":"global">
@@ -34,6 +33,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 }
 
 // -----
+
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: atomic_add_f32_scalar
@@ -871,33 +871,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
   tt.func private @callee_zero_scratch() attributes {noinline = true} {
-    tt.return
-  }
-}
-
-// -----
-
-/// gfx906 has the same dot intrinsics as gfx908+ (HasDot1Insts) but not
-/// the compact VOP2 encoding (HasDot2Insts); LLVM handles this transparently.
-
-// GFX906-LABEL: v_dot_fp16_gfx906
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
-module attributes {"ttg.target" = "hip:gfx906", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @v_dot_fp16_gfx906(%arg0: tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xf32, #blocked>) {
-    // GFX906-COUNT-8: llvm.call_intrinsic "llvm.amdgcn.fdot2"
-    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xf32, #blocked>
-    tt.return
-  }
-}
-
-// -----
-
-// GFX906-LABEL: v_dot_i8_gfx906
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
-module attributes {"ttg.target" = "hip:gfx906", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @v_dot_i8_gfx906(%arg0: tensor<16x16xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>, %arg1: tensor<16x16xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>, %arg2: tensor<16x16xi32, #blocked>) {
-    // GFX906-COUNT-4: llvm.call_intrinsic "llvm.amdgcn.sdot4"
-    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<16x16xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<16x16xi32, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -706,7 +706,7 @@ public:
   LogicalResult
   matchAndRewrite(triton::gpu::BarrierOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (targetInfo.getIsaVersion().Major < 9)
+    if (!mlir::triton::amdgpu::isCDNA(targetInfo.getISAFamily()))
       return failure();
     // Check no other memory addrspaces are selected.
     // TensorRead/Write are allowed but noop.


### PR DESCRIPTION
## Summary

Cherry-pick of `eaad84b14` / #10906 onto `release/internal/3.8.x`.

This restricts AMD `BarrierOpConversion` to CDNA targets, avoiding RDNA local-only MMRA fence lowering on the internal 3.8 release branch used by ROCm Triton packages.

## Motivation

ROCm JIRA: https://amd-hub.atlassian.net/browse/ROCM-30341

The ROCm 3.8 wheels are built from commits on `release/internal/3.8.x` (for example `4cff872c` and later `fccf16653`), not the public `release/3.8.x` branch. Those commits include #10383 and #9416 but not #10906. This leaves local-MMRA barrier lowering active on RDNA.

For generated Triton kernels that contain a global/raw-buffer scratch store followed by a later reload across a local-tagged barrier, final AMDGCN can omit `s_waitcnt_vscnt`, causing nondeterministic outputs under memory pressure.

Local investigation showed:

- `torch 20260721 + triton 20260721` => OK (`s_waitcnt_vscnt=52`)
- `torch 20260721 + triton 20260723` => defective (`s_waitcnt_vscnt=0`)
- `torch 20260723 + triton 20260721` => OK (`s_waitcnt_vscnt=52`)
- latest whl-next `torch 2.13.0+rocm10.1.0a20260826 / triton 3.8.0+git4cff872c` remains defective (`s_waitcnt_vscnt=0`)

A diagnostic patch removing local-only MMRA tags restored vector-store waits in the generated AMDGCN scan (`s_waitcnt_vscnt=49`). This cherry-pick is the existing conservative upstream mitigation for RDNA.

## Notes

The cherry-pick had one test-file conflict. It was resolved by taking #10906's layout: adding `test/Conversion/amd/barrier_op_to_llvm.mlir` and removing the old test block from `tritongpu_to_llvm.mlir`.

Related:
- #10383
- #9416
- #10906
- #11289
- ROCM-30341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
